### PR TITLE
add source-map-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -176,6 +176,13 @@ module.exports = {
               cacheDirectory: true,
             },
           },
+          {
+            test: /\.js$/,
+            use: [
+              require.resolve('source-map-loader')
+            ],
+            enforce: 'pre'
+          },
           // "postcss" loader applies autoprefixer to our CSS.
           // "css" loader resolves paths in CSS and adds assets as dependencies.
           // "style" loader turns CSS into JS modules that inject <style> tags.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "react-scripts",
+  "name": "@paperlesspost/react-scripts",
   "version": "1.1.1",
   "description": "Configuration and scripts for Create React App.",
-  "repository": "facebookincubator/create-react-app",
+  "repository": "paperlesspost/create-react-app",
   "license": "MIT",
   "engines": {
     "node": ">=6"
   },
   "bugs": {
-    "url": "https://github.com/facebookincubator/create-react-app/issues"
+    "url": "https://github.com/paperlesspost/create-react-app/issues"
   },
   "files": [
     "bin",
@@ -51,6 +51,7 @@
     "promise": "8.0.1",
     "raf": "3.4.0",
     "react-dev-utils": "^5.0.0",
+    "source-map-loader": "^0.2.3",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",


### PR DESCRIPTION
This is already published as https://www.npmjs.com/package/@paperlesspost/react-scripts `v1.1.1`

I made `paperlesspost` the default branch for our fork. We can merge future changes into that branch and deploy from there.