### PR TITLE
add styled-components babel plugin and alias to prevent duplicate copies

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -104,6 +104,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'styled-components': path.resolve(paths.appPath, 'node_modules', 'styled-components')
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -171,6 +171,7 @@ module.exports = {
               babelrc: false,
               presets: [require.resolve('babel-preset-react-app')],
               // @remove-on-eject-end
+              plugins: [require.resolve('babel-plugin-styled-components')],
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
               // directory for faster rebuilds.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -178,6 +178,7 @@ module.exports = {
               babelrc: false,
               presets: [require.resolve('babel-preset-react-app')],
               // @remove-on-eject-end
+              plugins: [require.resolve('babel-plugin-styled-components')],
               compact: true,
             },
           },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -110,6 +110,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'styled-components': path.resolve(paths.appPath, 'node_modules', 'styled-components')
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).

--- a/packages/react-scripts/fixtures/kitchensink/.babelrc
+++ b/packages/react-scripts/fixtures/kitchensink/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["react-app"],
-  "plugins": ["babel-plugin-styled-components", babel-plugin-transform-es2015-modules-commonjs"]
+  "plugins": ["babel-plugin-transform-es2015-modules-commonjs"]
 }

--- a/packages/react-scripts/fixtures/kitchensink/.babelrc
+++ b/packages/react-scripts/fixtures/kitchensink/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["react-app"],
-  "plugins": ["babel-plugin-transform-es2015-modules-commonjs"]
+  "plugins": ["babel-plugin-styled-components", babel-plugin-transform-es2015-modules-commonjs"]
 }

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,0 +1,93 @@
+{
+  "name": "@paperlesspost/react-scripts",
+  "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.48.tgz",
+      "integrity": "sha512-LBldrgCApkHFwwtMJC2P2MeH+09+vPVj3Gs+mltqSpY+LyowjjUmqLUcmrF+Kj/gmRY/DqGAbvZWwNlNDs6dGQ==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.48"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.48",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.48.tgz",
+      "integrity": "sha512-h37aY8aUmTMEDEaPrNwmYmwSTjf7SvJ4h8jCljaHOSq3785TZSZnxdCsNDVs+fKK21lOPh9X29rvOLTOwxgVmw==",
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.5",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "babel-plugin-styled-components": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.5.1.tgz",
+      "integrity": "sha1-MdvraW0TVNFYXmDWbHkF9eR0r80=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0-beta.37",
+        "babel-types": "^6.26.0",
+        "stylis": "^3.0.0"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+        }
+      }
+    },
+    "core-js": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+      "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "stylis": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
+      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    }
+  }
+}

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperlesspost/react-scripts",
-  "version": "1.1.1",
+  "version": "1.1.2-pre",
   "description": "Configuration and scripts for Create React App.",
   "repository": "paperlesspost/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -26,6 +26,7 @@
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",
     "babel-loader": "7.1.2",
+    "babel-plugin-styled-components": "^1.5.1",
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperlesspost/react-scripts",
-  "version": "1.1.2-pre2",
+  "version": "1.1.2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "paperlesspost/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperlesspost/react-scripts",
-  "version": "1.1.2-pre",
+  "version": "1.1.2-pre2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "paperlesspost/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
https://www.styled-components.com/docs/tooling

https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page

Even with all `flyer-rendering-system` using `peerDependencies`  and `external` we're still seeing styled-components get pulled into the build twice.

`babel-plugin-styled-components` is the part of example used in the CRA fork tutorial video
https://www.youtube.com/watch?v=I22TW-33dDE

published and available as `@paperlesspost/react-scripts@1.1.2`