### PR TITLE
PFR-2316: changed source map generation to inline

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -36,7 +36,7 @@ const env = getClientEnvironment(publicUrl);
 module.exports = {
   // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
   // See the discussion in https://github.com/facebookincubator/create-react-app/issues/343.
-  devtool: 'cheap-module-source-map',
+  devtool: 'inline-cheap-module-source-map',
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperlesspost/react-scripts",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Configuration and scripts for Create React App.",
   "repository": "paperlesspost/create-react-app",
   "license": "MIT",


### PR DESCRIPTION
Fixed source maps not showing up properly in our browsers.

The nGinx config requires a referer header to load the correct source map. The browser does not provide the referer header when loading source maps. nGinx defaults to the application running on port 3003. To ensure source maps are available for all projects running on all ports, the easiest change is to provide an inline source map.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
